### PR TITLE
'Fixed' WJSONObject.toString() to serialise null field values as a

### DIFF
--- a/sapi-lib/src/main/java/com/epimorphics/simpleAPI/results/wappers/WJSONObject.java
+++ b/sapi-lib/src/main/java/com/epimorphics/simpleAPI/results/wappers/WJSONObject.java
@@ -229,6 +229,7 @@ public class WJSONObject {
     @Override
     public String toString() {
         StringBuffer buf = new StringBuffer();
+        Object o = null;
         buf.append("{");
         boolean started = false;
         for (String key : properties.keySet()) {
@@ -239,7 +240,7 @@ public class WJSONObject {
             }
             buf.append(key);
             buf.append(": ");
-            buf.append( properties.get(key).toString() );
+            buf.append( (o = properties.get(key))==null ? "null" : o.toString() );
         }
         buf.append("}");
         return buf.toString();


### PR DESCRIPTION
WJSONObject.toString() throws an NPE exception if the value of an object key is 'null'. This is problematic when debugging VM templates because either page rendering terminates or the corresponding template expression appears to be skipped.

I've modified .toString() to detect a 'null' valued key and render a literal 'null'. An alternate approach would be to suppress the inclusion of the null valued key in the object being serialised.