### PR TITLE
Minor dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <appbase.version>4.0.1</appbase.version>
+      <appbase.version>4.0.3</appbase.version>
       <jersey.version>3.1.11</jersey.version>
     <tomcat.version>11.0.21</tomcat.version>
   </properties>

--- a/sapi-lib/pom.xml
+++ b/sapi-lib/pom.xml
@@ -49,6 +49,10 @@
                 <artifactId>commons-io</artifactId>
                 <groupId>commons-io</groupId>
             </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
         </exclusions>
     </dependency>
 
@@ -61,7 +65,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.21</version>
+      <version>1.5.25</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
* appbase -> 4.0.3 to address vulnerability in transitive dependency
* Add an exclusion for the overridden commons-code to stop intellij complaining about it